### PR TITLE
Fix leaked objects; call onOpen asynchronously

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@
 ^/tmp$
 ^tmp
 ^/windows$
+.travis.yml
+^.vscode$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: r
+sudo: false
+cache: packages
+r:
+  - oldrel
+  - release
+  - devel

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -29,8 +29,8 @@ wsReset <- function(client_xptr) {
     invisible(.Call(`_websocket_wsReset`, client_xptr))
 }
 
-wsClose <- function(client_xptr) {
-    invisible(.Call(`_websocket_wsClose`, client_xptr))
+wsClose <- function(client_xptr, code, reason) {
+    invisible(.Call(`_websocket_wsClose`, client_xptr, code, reason))
 }
 
 wsStopped <- function(client_xptr) {

--- a/R/websocket.R
+++ b/R/websocket.R
@@ -138,11 +138,9 @@ WebsocketClient <- R6::R6Class("WebsocketClient",
     },
     send = function(msg) {
       wsSend(private$wsObj, msg)
-      # TODO Call wsPoll here?
     },
-    close = function() {
-      wsClose(private$wsObj)
-      # TODO Call wsPoll here?
+    close = function(code = 1000L, reason = "") {
+      wsClose(private$wsObj, code, reason)
     },
     setAccessLogChannels = function(channels = c("all")) {
       wsUpdateLogChannels(private$wsObj, "access", "set", private$accessLogChannels(channels, "none"))

--- a/R/websocket.R
+++ b/R/websocket.R
@@ -3,6 +3,9 @@
 #' @include RcppExports.R
 NULL
 
+# Used to "null out" handler functions after a websocket client is closed
+null_func <- function(...) { }
+
 #' Create a websocket client
 #'
 #' @details

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -86,12 +86,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // wsClose
-void wsClose(SEXP client_xptr);
-RcppExport SEXP _websocket_wsClose(SEXP client_xptrSEXP) {
+void wsClose(SEXP client_xptr, uint16_t code, std::string reason);
+RcppExport SEXP _websocket_wsClose(SEXP client_xptrSEXP, SEXP codeSEXP, SEXP reasonSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type client_xptr(client_xptrSEXP);
-    wsClose(client_xptr);
+    Rcpp::traits::input_parameter< uint16_t >::type code(codeSEXP);
+    Rcpp::traits::input_parameter< std::string >::type reason(reasonSEXP);
+    wsClose(client_xptr, code, reason);
     return R_NilValue;
 END_RCPP
 }
@@ -139,7 +141,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_websocket_wsPoll", (DL_FUNC) &_websocket_wsPoll, 1},
     {"_websocket_wsSend", (DL_FUNC) &_websocket_wsSend, 2},
     {"_websocket_wsReset", (DL_FUNC) &_websocket_wsReset, 1},
-    {"_websocket_wsClose", (DL_FUNC) &_websocket_wsClose, 1},
+    {"_websocket_wsClose", (DL_FUNC) &_websocket_wsClose, 3},
     {"_websocket_wsStopped", (DL_FUNC) &_websocket_wsStopped, 1},
     {"_websocket_wsState", (DL_FUNC) &_websocket_wsState, 1},
     {"_websocket_wsUpdateLogChannels", (DL_FUNC) &_websocket_wsUpdateLogChannels, 4},

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -203,12 +203,6 @@ void wsAppendHeader(SEXP client_xptr, std::string key, std::string value) {
 void wsConnect(SEXP client_xptr) {
   shared_ptr<WSConnection> wsPtr = xptrGetClient(client_xptr);
   wsPtr->client->connect();
-  // Block until the connection is either open, closed, or the attempt to connect has failed.
-  // wsPtr->client->run() would block indefinitely, so we use run_one() instead.
-  // We don't need to call restart() here because the underlying io_context is never out of work between invocations.
-  while (wsPtr->state == WSConnection::STATE::INIT) {
-    wsPtr->client->run_one();
-  }
 }
 
 // [[Rcpp::export]]

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -243,10 +243,10 @@ void wsReset(SEXP client_xptr) {
 }
 
 // [[Rcpp::export]]
-void wsClose(SEXP client_xptr) {
+void wsClose(SEXP client_xptr, uint16_t code, std::string reason) {
   shared_ptr<WSConnection> wsPtr = xptrGetClient(client_xptr);
 
-  wsPtr->client->close(ws_websocketpp::close::status::normal, "closing normally");
+  wsPtr->client->close(code, reason);
 }
 
 // [[Rcpp::export]]

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -30,6 +30,7 @@ using namespace Rcpp;
 // used. If so, ws_websocketpp::lib::shared_ptr is a std::shared_ptr. If not,
 // ws_websocketpp::lib::shared_ptr is a boost::shared_ptr.
 using ws_websocketpp::lib::shared_ptr;
+using ws_websocketpp::lib::weak_ptr;
 using ws_websocketpp::lib::make_shared;
 
 using ws_websocketpp::lib::placeholders::_1;
@@ -55,11 +56,18 @@ static context_ptr on_tls_init() {
 
 class WSConnection {
 public:
-  WSConnection(shared_ptr<Client> client) : client(client) {};
+  WSConnection(shared_ptr<Client> client, Rcpp::Function onMessage,
+    Rcpp::Function onOpen, Rcpp::Function onClose, Rcpp::Function onFail) :
+  client(client), onMessage(onMessage), onOpen(onOpen), onClose(onClose), onFail(onFail) {}
 
   enum STATE { INIT, OPEN, CLOSED, FAILED };
   STATE state = INIT;
   shared_ptr<Client> client;
+
+  Rcpp::Function onMessage;
+  Rcpp::Function onOpen;
+  Rcpp::Function onClose;
+  Rcpp::Function onFail;
 };
 
 
@@ -75,33 +83,45 @@ void client_deleter(SEXP client_xptr) {
   R_ClearExternalPtr(client_xptr);
 }
 
-void handleMessage(Rcpp::Function onMessage, ws_websocketpp::connection_hdl, message_ptr msg) {
-  ws_websocketpp::frame::opcode::value opcode = msg->get_opcode();
-  if (opcode == ws_websocketpp::frame::opcode::value::text) {
-    onMessage(msg->get_payload());
+void handleMessage(weak_ptr<WSConnection> wsPtrWeak, ws_websocketpp::connection_hdl, message_ptr msg) {
+  shared_ptr<WSConnection> wsPtr = wsPtrWeak.lock();
+  if (wsPtr) {
+    ws_websocketpp::frame::opcode::value opcode = msg->get_opcode();
+    if (opcode == ws_websocketpp::frame::opcode::value::text) {
+      wsPtr->onMessage(msg->get_payload());
 
-  } else if (opcode == ws_websocketpp::frame::opcode::value::binary) {
-    const std::string msg_str = msg->get_payload();
-    onMessage(std::vector<uint8_t>(msg_str.begin(), msg_str.end()));
+    } else if (opcode == ws_websocketpp::frame::opcode::value::binary) {
+      const std::string msg_str = msg->get_payload();
+      wsPtr->onMessage(std::vector<uint8_t>(msg_str.begin(), msg_str.end()));
 
-  } else {
-    stop("Unknown opcode for message (not text or binary).");
+    } else {
+      stop("Unknown opcode for message (not text or binary).");
+    }
   }
 }
 
-void handleClose(shared_ptr<WSConnection> wsPtr, Rcpp::Function onClose, ws_websocketpp::connection_hdl) {
-  wsPtr->state = WSConnection::STATE::CLOSED;
-  onClose();
+void handleClose(weak_ptr<WSConnection> wsPtrWeak, ws_websocketpp::connection_hdl) {
+  shared_ptr<WSConnection> wsPtr = wsPtrWeak.lock();
+  if (wsPtr) {
+    wsPtr->state = WSConnection::STATE::CLOSED;
+    wsPtr->onClose();
+  }
 }
 
-void handleOpen(shared_ptr<WSConnection> wsPtr, Rcpp::Function onOpen, ws_websocketpp::connection_hdl) {
-  wsPtr->state = WSConnection::STATE::OPEN;
-  onOpen();
+void handleOpen(weak_ptr<WSConnection> wsPtrWeak, ws_websocketpp::connection_hdl) {
+  shared_ptr<WSConnection> wsPtr = wsPtrWeak.lock();
+  if (wsPtr) {
+    wsPtr->state = WSConnection::STATE::OPEN;
+    wsPtr->onOpen();
+  }
 }
 
-void handleFail(shared_ptr<WSConnection> wsPtr, Rcpp::Function onFail, ws_websocketpp::connection_hdl) {
-  wsPtr->state = WSConnection::STATE::FAILED;
-  onFail();
+void handleFail(weak_ptr<WSConnection> wsPtrWeak, ws_websocketpp::connection_hdl) {
+  shared_ptr<WSConnection> wsPtr = wsPtrWeak.lock();
+  if (wsPtr) {
+    wsPtr->state = WSConnection::STATE::FAILED;
+    wsPtr->onFail();
+  }
 }
 
 // [[Rcpp::export]]
@@ -122,24 +142,26 @@ SEXP wsCreate(
 
   if (uri.substr(0, 5) == "ws://") {
     shared_ptr<ClientImpl<ws_client>> client = make_shared<ClientImpl<ws_client>>();
-    wsPtr = make_shared<WSConnection>(client);
+    wsPtr = make_shared<WSConnection>(client, onMessage, onOpen, onClose, onFail);
 
   } else if (uri.substr(0, 6) == "wss://") {
     shared_ptr<ClientImpl<wss_client>> client = make_shared<ClientImpl<wss_client>>();
-    wsPtr = make_shared<WSConnection>(client);
+    wsPtr = make_shared<WSConnection>(client, onMessage, onOpen, onClose, onFail);
     wsPtr->client->set_tls_init_handler(bind(&on_tls_init));
 
   } else {
     throw Rcpp::exception("Invalid websocket URI: must begin with ws:// or wss://");
   }
 
+  weak_ptr<WSConnection> wsPtrWeak(wsPtr);
+
   wsPtr->client->update_log_channels("access", "set", accessLogChannels);
   wsPtr->client->update_log_channels("error", "set", errorLogChannels);
   wsPtr->client->init_asio();
-  wsPtr->client->set_open_handler(bind(handleOpen, wsPtr, onOpen, ::_1));
-  wsPtr->client->set_message_handler(bind(handleMessage, onMessage, ::_1, ::_2));
-  wsPtr->client->set_close_handler(bind(handleClose, wsPtr, onClose, ::_1));
-  wsPtr->client->set_fail_handler(bind(handleFail, wsPtr, onFail, ::_1));
+  wsPtr->client->set_open_handler(bind(handleOpen, wsPtrWeak, ::_1));
+  wsPtr->client->set_message_handler(bind(handleMessage, wsPtrWeak, ::_1, ::_2));
+  wsPtr->client->set_close_handler(bind(handleClose, wsPtrWeak, ::_1));
+  wsPtr->client->set_fail_handler(bind(handleFail, wsPtrWeak, ::_1));
 
   ws_websocketpp::lib::error_code ec;
   wsPtr->client->setup_connection(uri, ec);
@@ -199,7 +221,6 @@ void wsSend(SEXP client_xptr, SEXP msg) {
 
   } else if (TYPEOF(msg) == RAWSXP) {
     wsPtr->client->send(RAW(msg), Rf_length(msg), ws_websocketpp::frame::opcode::binary);
-
   } else {
     stop("msg must be a one-element character vector or a raw vector.");
   }
@@ -214,7 +235,18 @@ void wsReset(SEXP client_xptr) {
 // [[Rcpp::export]]
 void wsClose(SEXP client_xptr) {
   shared_ptr<WSConnection> wsPtr = xptrGetClient(client_xptr);
+
   wsPtr->client->close(ws_websocketpp::close::status::normal, "closing normally");
+
+  // Replace handler functions with `null_func` to break reference counting cycles
+  Rcpp::Environment websocket_namespace = Rcpp::Environment::namespace_env("websocket");
+  Rcpp::Function func(websocket_namespace.get("null_func"));
+  wsPtr->onOpen = func;
+  wsPtr->onMessage = func;
+  // Is it safe to clear out onFail/onClose here? Or do we need to wait for
+  // the server to respond with its own close() first?
+  wsPtr->onFail = func;
+  wsPtr->onClose = func;
 }
 
 // [[Rcpp::export]]

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -113,6 +113,15 @@ test_that("WebSocket object can be garbage collected", {
   expect_true(collected)
 })
 
+test_that("Open is async", {
+  ws <- WebsocketClient$new("ws://echo.websocket.org",
+    onOpen = function() {
+      ws$close()
+    })
+  Sys.sleep(1)
+  expect_identical(ws$getState(), "INIT")
+})
+
 
 context("Basic SSL WebSocket")
 test_that("Basic ssl websocket communication", {


### PR DESCRIPTION
Fixes #14.

- [x] Unit tests

### Testing notes

I think unit tests are appropriate enough for this. You can try the repro in #14 but the unit test I added is almost exactly the same.