### PR TITLE
Clear all channels on ws init if any non-`NULL` channel value is provided

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports: Rcpp,
     later
 LinkingTo: Rcpp, BH, AsioHeaders
 SystemRequirements: GNU make, OpenSSL >= 1.0.1
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.0
 Collate:
     'RcppExports.R'
     'websocket.R'

--- a/R/websocket.R
+++ b/R/websocket.R
@@ -83,8 +83,8 @@ null_func <- function(...) { }
 #'   WebSocket object (i.e. you are constructing a WebSocket object manually at
 #'   an interactive R console); after you are done attaching event handlers, you
 #'   must call `ws$connect()` to establish the WebSocket connection.
-#' @param accessLogChannels A character vector of access log channels that should
-#'   be enabled.  Defaults to \code{"none"}, which displays no normal, websocketpp logging activity.
+#' @param accessLogChannels A character vector of access log channels that are
+#'   enabled.  Defaults to \code{"none"}, which displays no normal, websocketpp logging activity.
 #'   Setting \code{accessLogChannels = NULL} will use default websocketpp behavior.
 #'   Multiple access logging levels may be passed in for them to be enabled.
 #'
@@ -99,8 +99,8 @@ null_func <- function(...) { }
 #'   }
 #'
 #'   All logging levels are explained in more detail at \url{https://www.zaphoyd.com/websocketpp/manual/reference/logging}.
-#' @param errorLogChannels A character vector of error log channels that should
-#'   be displayed.  The default value is \code{NULL}, which will use default websocketpp behavior.
+#' @param errorLogChannels A character vector of error log channels that are
+#'   displayed.  The default value is \code{NULL}, which will use default websocketpp behavior.
 #'   Multiple error logging levels may be passed in for them to be enabled.
 #'
 #'   A few commonly used error logging values are:
@@ -145,7 +145,7 @@ WebSocket <- R6::R6Class("WebSocket",
       headers = NULL,
       autoConnect = TRUE,
       accessLogChannels = c("none"),
-      errorLogChannels = c("none")
+      errorLogChannels = NULL
     ) {
       private$callbacks <- new.env(parent = emptyenv())
       private$callbacks$open <- Callbacks$new()

--- a/man/WebSocket.Rd
+++ b/man/WebSocket.Rd
@@ -19,8 +19,8 @@ WebSocket object (i.e. you are constructing a WebSocket object manually at
 an interactive R console); after you are done attaching event handlers, you
 must call `ws$connect()` to establish the WebSocket connection.}
 
-\item{accessLogChannels}{A character vector of access log channels that should
-  be enabled.  Defaults to \code{"none"}, which displays no normal, websocketpp logging activity.
+\item{accessLogChannels}{A character vector of access log channels that are
+  enabled.  Defaults to \code{"none"}, which displays no normal, websocketpp logging activity.
   Setting \code{accessLogChannels = NULL} will use default websocketpp behavior.
   Multiple access logging levels may be passed in for them to be enabled.
 
@@ -36,8 +36,8 @@ must call `ws$connect()` to establish the WebSocket connection.}
 
   All logging levels are explained in more detail at \url{https://www.zaphoyd.com/websocketpp/manual/reference/logging}.}
 
-\item{errorLogChannels}{A character vector of error log channels that should
-  be displayed.  The default value is \code{NULL}, which will use default websocketpp behavior.
+\item{errorLogChannels}{A character vector of error log channels that are
+  displayed.  The default value is \code{NULL}, which will use default websocketpp behavior.
   Multiple error logging levels may be passed in for them to be enabled.
 
   A few commonly used error logging values are:

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -192,8 +192,16 @@ SEXP wsCreate(
 
   weak_ptr<WSConnection> wsPtrWeak(wsPtr);
 
-  wsPtr->client->update_log_channels("access", "set", accessLogChannels);
-  wsPtr->client->update_log_channels("error", "set", errorLogChannels);
+  if (accessLogChannels.size() > 0) {
+    // clear all channels and set user channels
+    wsPtr->client->clear_access_channels(ws_websocketpp::log::alevel::all);
+    wsPtr->client->update_log_channels("access", "set", accessLogChannels);
+  }
+  if (errorLogChannels.size() > 0) {
+    // clear all channels and set user channels
+    wsPtr->client->clear_error_channels(ws_websocketpp::log::elevel::all);
+    wsPtr->client->update_log_channels("error", "set", errorLogChannels);
+  }
   wsPtr->client->init_asio();
   wsPtr->client->set_open_handler(bind(handleOpen, wsPtrWeak, ::_1));
   wsPtr->client->set_message_handler(bind(handleMessage, wsPtrWeak, ::_1, ::_2));


### PR DESCRIPTION
```r
# NO extra logging
ws <- Websocket$new("ws://echo.websocket.org/")
ws$send("hello")
ws$close()

# LOTS of extra logging
ws <- Websocket$new("ws://echo.websocket.org/", accessLogChannels = "all")
ws$send("hello")
ws$close()

# ONLY logging levels of "frame_header" or "disconnect"
ws <- Websocket$new("ws://echo.websocket.org/", accessLogChannels = c("frame_header", "disconnect"))
ws$send("hello")
ws$close()
```