### PR TITLE
Catch exceptions in callbacks

### DIFF
--- a/R/websocket.R
+++ b/R/websocket.R
@@ -302,7 +302,16 @@ Callbacks <- R6::R6Class(
       callbacks <- mget(keys, private$.callbacks)
 
       for (callback in callbacks) {
-        callback(...)
+        tryCatch(
+          callback(...),
+          error = function(e) {
+            message("Error in websocket callback: ", e$message)
+          },
+          interrupt = function(e) {
+            message("Interrupt received while executing websocket callback.")
+          }
+        )
+
       }
     },
     count = function() {


### PR DESCRIPTION
This fixes #38.

Here's a test app. It should be run interactively at the console, stepping through each command:

```R
ws <- websocket::WebSocket$new("ws://echo.websocket.org")
ws$onMessage(function(event) {
  message("Message received: ", event$data)
  stop("error here")
})

ws$send("hello")

ws$send("hello")
```

Previously, the first `ws$send()` printed `"Message received: hello"`, followed by an error message, and the second resulted in nothing. The websocket would no longer be responsive at all after the first `ws$send()`.

```
> ws$send("hello")
Message received: hello
later: exception occurred while executing callback: 
Evaluation error: Evaluation error: error here..

> ws$send("hello") 
[Nothing happens]
```


After this fix, both calls to `ws$send()` result in the message and error:

```
> ws$send("hello")
Message received: hello
Error in websocket callback: error here

> ws$send("hello")
Message received: hello
Error in websocket callback: error here
```

This fix also handles the case where an interrupt is received during the callback. With the code below, after it prints "Message received: hello", press Ctrl-C within 5 seconds. The before and after behavior is similar to the version above, with `stop()`; the only difference is that instead of an error, the exception is an interrupt.

```R
ws <- websocket::WebSocket$new("ws://echo.websocket.org")
ws$onMessage(function(event) {
  message("Message received: ", event$data)
  Sys.sleep(5) # Press Ctrl-C at this point
})

ws$send("hello")

ws$send("hello")
```


One drawback to this fix is that `options(error=recover)` won't work, because the exception doesn't bubble up to the top level. The overall structure of the callback mechanism is that R calls C++, which in turn calls R, and the exception is caught in the latter R call. The problem is that the websocket stops working if an exception bubbles up through the C++ asio code, specifically if the exception goes from the `handleMessage` function up to the `poll` call.