### PR TITLE
Make sure openssl is downloaded before compiling on Windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -5,7 +5,13 @@ PKG_LIBS= -L../windows/openssl-$(OPENSSL_VERSION)/lib${R_ARCH} -lssl -lcrypto -l
 
 CXX_STD=CXX11
 
-all: clean winlibs
+.PHONY: all winlibs
+
+all: $(SHLIB)
+
+# Need to make sure that openssl is fully downloaded before trying to compile
+# websocket.cpp. See https://github.com/rstudio/websocket/issues/43
+$(OBJECTS): winlibs
 
 clean:
 	rm -f $(SHLIB) $(OBJECTS)


### PR DESCRIPTION
This fixes #43.

The pattern is borrowed from: https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Using-Makevars
