### PR TITLE
Small autobrew tweak

### DIFF
--- a/configure
+++ b/configure
@@ -10,7 +10,7 @@ PKG_CONFIG_NAME="openssl"
 PKG_DEB_NAME="libssl-dev"
 PKG_RPM_NAME="openssl-devel"
 PKG_CSW_NAME="libssl_dev"
-PKG_BREW_NAME="openssl@1.1"
+PKG_BREW_NAME="openssl"
 PKG_TEST_FILE="tools/version.c"
 PKG_LIBS="-lssl -lcrypto"
 PKG_CFLAGS=""
@@ -36,12 +36,12 @@ else
   brew --version 2>/dev/null
   if [ $? -eq 0 ]; then
     BREWDIR=`brew --prefix`
+    PKG_CFLAGS="-I$BREWDIR/opt/openssl/include"
+    PKG_LIBS="-L$BREWDIR/opt/openssl/lib $PKG_LIBS"
   else
-    curl -sfL "https://autobrew.github.io/scripts/$PKG_BREW_NAME" > autobrew
+    curl -sfL "https://autobrew.github.io/scripts/openssl" > autobrew
     source autobrew
   fi
-  PKG_CFLAGS="-I$BREWDIR/opt/openssl@1.1/include -I$BREWDIR/opt/openssl/include"
-  PKG_LIBS="-L$BREWDIR/opt/openssl@1.1/lib -L$BREWDIR/opt/openssl/lib $PKG_LIBS"
   ;;
   esac
 fi


### PR DESCRIPTION
It is now recommended to let the autobrew script set PKG_LIBS and PKG_CFLAGS.

And while I was at it, as of last year `openssl` and `openssl@1.1` are synonymous now in homebrew.