### PR TITLE
Fix rwinlib for ucrt toolchains

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,7 +2,7 @@ OPENSSL_VERSION=1.1.1g
 
 # Some settings from https://github.com/zaphoyd/websocketpp/issues/478
 PKG_CPPFLAGS=-I./lib -I../windows/openssl-$(OPENSSL_VERSION)/include -D_WEBSOCKETPP_CPP11_THREAD_
-PKG_LIBS= -L../windows/openssl-$(OPENSSL_VERSION)/lib${R_ARCH} -lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32
+PKG_LIBS= -L../windows/openssl-$(OPENSSL_VERSION)/lib${R_ARCH}${CRT} -lssl -lcrypto -lz -lws2_32 -lgdi32 -lcrypt32
 
 CXX_STD=CXX11
 


### PR DESCRIPTION
Small fix to keep rwinlib binaries compatible with ucrt toolchains.