### PR TITLE
Updated demos from echo.websocket.org to echo.websocket.events.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
 LinkingTo: cpp11, AsioHeaders, later
 BugReports: https://github.com/rstudio/websocket/issues
 SystemRequirements: C++11, GNU make, OpenSSL >= 1.0.2
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Suggests:
     httpuv,
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # websocket (development version)
 
+* Update examples from websocket.org to websocket.events. (@jonthegeek, #105)
+
 # websocket 1.4.1
 
 * Add UCRT toolchain support (@jeroen, #82)

--- a/R/websocket.R
+++ b/R/websocket.R
@@ -124,8 +124,8 @@ null_func <- function(...) { }
 #' ## Only run this example in interactive R sessions
 #' if (interactive()) {
 #'
-#' # Create a websocket using the websocket.org test server
-#' ws <- WebSocket$new("ws://echo.websocket.org/")
+#' # Create a websocket using the websocket.events test server
+#' ws <- WebSocket$new("ws://echo.websocket.events/")
 #' ws$onMessage(function(event) {
 #'   cat("Client got msg:", event$data, "\n")
 #' })

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is an R WebSocket client library backed by the [websocketpp](https://github
 ```R
 library(websocket)
 
-ws <- WebSocket$new("ws://echo.websocket.org/", autoConnect = FALSE)
+ws <- WebSocket$new("ws://echo.websocket.events/", autoConnect = FALSE)
 ws$onOpen(function(event) {
   cat("Connection opened\n")
 })
@@ -47,7 +47,7 @@ ws$close()
 Note that if you want to `send()` a message as soon as it connects, without having to wait at the console, you can put the `ws$send()` inside of the `ws$onOpen` callback, as in:
 
 ```R
-ws <- WebSocket$new("wss://echo.websocket.org/")
+ws <- WebSocket$new("wss://echo.websocket.events/")
 ws$onMessage(function(event) {
   cat("Client got msg: ", event$data, "\n")
 })
@@ -64,7 +64,7 @@ ws$onOpen(function(event) {
 The websocket (client) package can be used with a WebSocket server, implemented as a httpuv web application, to act as a WebSocket proxy. This proxy can be modified do things like log the traffic in each direction, or
 modify messages sent in either direction.
 
-The proxy will listen to port 5002 on the local machine, and connect to the remote machine at wss://echo.websocket.org:80. In this example, after starting the proxy, we'll connect to it with a WebSocket client in a separate R process, then send a message from that process. Here's what will happen in the proxy:
+The proxy will listen to port 5002 on the local machine, and connect to the remote machine at wss://echo.websocket.events:80. In this example, after starting the proxy, we'll connect to it with a WebSocket client in a separate R process, then send a message from that process. Here's what will happen in the proxy:
 
 * The client will send the message `"hello"`.
 * The proxy will receive `"hello"` from the client, convert it to `"HELLO"`, then send it to the remote echo server.
@@ -80,7 +80,7 @@ library(httpuv)
 library(websocket)
 
 # URL of the remote websocket server
-target_host <- "echo.websocket.org:80"
+target_host <- "echo.websocket.events:80"
 # Should be "ws" or "wss"
 target_protocol <- "ws"
 

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -443,12 +443,9 @@ test_that("WebSocket persists after reference is gone, and can be GC'd after con
   expect_true(finalized)
 })
 
-
-
-# # Test is failing now that websocket.org is dead
-# test_that("Basic ssl websocket communication", {
-#   # Don't want network connectivity issues on CRAN to cause package to be
-#   # rejected.
-#   skip_on_cran()
-#   check_ws("wss://echo.websocket.org/")
-# })
+test_that("Basic ssl websocket communication", {
+  # Don't want network connectivity issues on CRAN to cause package to be
+  # rejected.
+  skip_on_cran()
+  check_ws("wss://echo.websocket.events/")
+})

--- a/vignettes/overview.Rmd
+++ b/vignettes/overview.Rmd
@@ -28,7 +28,7 @@ The I/O for a WebSocket happens on a separate thread from the main R thread; the
 WebSockets are represented as instances of an [R6](https://github.com/r-lib/R6) object, and are created with `$new()`:
 
 ```{r, eval = FALSE}
-ws <- WebSocket$new("ws://echo.websocket.org/")
+ws <- WebSocket$new("ws://echo.websocket.events/")
 ```
 
 By default, and similarly to how WebSockets in JavaScript work, constructing a WebSocket with `$new()` will automatically initiate the WebSocket connection. In normal usage, such as in a Shiny app or from within a function, this default behavior is ideal. When run interactively from the R console however, the default behavior is problematic. The reason is that the connection will open before the user is given an opportunity to register any event handlers, meaning messages from the server could be dropped.
@@ -36,7 +36,7 @@ By default, and similarly to how WebSockets in JavaScript work, constructing a W
 So, in the console, WebSockets should be created like this:
 
 ```{r, eval = FALSE}
-ws <- WebSocket$new("ws://echo.websocket.org/", autoConnect = FALSE)
+ws <- WebSocket$new("ws://echo.websocket.events/", autoConnect = FALSE)
 # Set up callbacks here...
 ws$connect()
 ```
@@ -51,7 +51,7 @@ When running a block of code like this in a function, or surrounded with `{` and
 
 ```{r, eval = FALSE}
 {
-  ws <- WebSocket$new("ws://echo.websocket.org/")
+  ws <- WebSocket$new("ws://echo.websocket.events/")
   ws$onOpen(function(event) { message("websocket opened") })
 }
 ```
@@ -75,7 +75,7 @@ For example, the following code instantiates a WebSocket, installs an `onOpen` h
 
 ```{r, eval = FALSE}
 {
-  ws <- WebSocket$new("ws://echo.websocket.org/")
+  ws <- WebSocket$new("ws://echo.websocket.events/")
   ws$onOpen(function(event) {
     cat("connected\n")
   })
@@ -108,7 +108,7 @@ The following is an example of an `$onMessage()` handler that immediately remove
 
 ```{r, eval = FALSE}
 {
-  ws <- WebSocket$new("ws://echo.websocket.org/")
+  ws <- WebSocket$new("ws://echo.websocket.events/")
   removeThis <- ws$onMessage(function(event) {
     cat("this is the last time i'll run\n")
     removeThis()


### PR DESCRIPTION
Closes #105.

I used the websocket.events service as described in the [websocket-client](https://github.com/websocket-client/websocket-client/issues/779) repo. I have no affiliation with websocket.events nor the websocket-client project, and make no guarantees about the continued availability of websocket.events.

CLA signed and emailed per #93.