### PR TITLE
Fixes for CRAN

### DIFF
--- a/src/lib/websocketpp/endpoint.hpp
+++ b/src/lib/websocketpp/endpoint.hpp
@@ -109,7 +109,7 @@ public:
 
 
     /// Destructor
-    ~endpoint<connection,config>() {}
+    ~endpoint() {}
 
     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
         // no copy constructor because endpoints are not copyable

--- a/src/lib/websocketpp/logger/basic.hpp
+++ b/src/lib/websocketpp/logger/basic.hpp
@@ -58,33 +58,33 @@ namespace log {
 template <typename concurrency, typename names>
 class basic {
 public:
-    basic<concurrency,names>(channel_type_hint::value h =
+    basic(channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? (std::ostream*)&WrappedOstream::cerr : (std::ostream*)&WrappedOstream::cout) {}
 
-    basic<concurrency,names>(std::ostream * out)
+    basic(std::ostream * out)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(out) {}
 
-    basic<concurrency,names>(level c, channel_type_hint::value h =
+    basic(level c, channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? (std::ostream*)&WrappedOstream::cerr : (std::ostream*)&WrappedOstream::cout) {}
 
-    basic<concurrency,names>(level c, std::ostream * out)
+    basic(level c, std::ostream * out)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(out) {}
 
     /// Destructor
-    ~basic<concurrency,names>() {}
+    ~basic() {}
 
     /// Copy constructor
-    basic<concurrency,names>(basic<concurrency,names> const & other)
+    basic(basic<concurrency,names> const & other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)
@@ -97,7 +97,7 @@ public:
 
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
     /// Move constructor
-    basic<concurrency,names>(basic<concurrency,names> && other)
+    basic(basic<concurrency,names> && other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)


### PR DESCRIPTION
This PR addresses the following issues:

```
Result: WARN 
  Found the following significant warnings:
    ./lib/websocketpp/logger/basic.hpp:61:49: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
    ./lib/websocketpp/logger/basic.hpp:67:35: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
    ./lib/websocketpp/logger/basic.hpp:72:30: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
    ./lib/websocketpp/logger/basic.hpp:78:30: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
    ./lib/websocketpp/logger/basic.hpp:84:5: warning: template-id not allowed for destructor in C++20 [-Wtemplate-id-cdtor]
    ./lib/websocketpp/logger/basic.hpp:87:30: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
    ./lib/websocketpp/logger/basic.hpp:100:30: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
    ./lib/websocketpp/endpoint.hpp:112:5: warning: template-id not allowed for destructor in C++20 [-Wtemplate-id-cdtor]
  See ‘/data/gannet/ripley/R/packages/tests-devel/websocket.Rcheck/00install.out’ for details.
```

```
Result: NOTE 
  File 'websocket/libs/x64/websocket.dll':
    Found non-API calls to R: 'R_nchar', 'Rf_findVarInFrame3',
      'SETLENGTH', 'SET_GROWABLE_BIT', 'SET_TRUELENGTH'
  
  Compiled code should not call non-API entry points in R.
  
  See 'Writing portable packages' in the 'Writing R Extensions' manual,
  and section 'Moving into C API compliance' for issues with the use of
  non-API entry points.
```