### PR TITLE
Use openssl from the system/Rtools on Windows.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,9 @@
-CRT=-ucrt
-include Makevars.win
+PKG_CPPFLAGS = -I./lib -D_WEBSOCKETPP_CPP11_THREAD_
+
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_LIBS = -lssl -lcrypto -lz -lws2_32 -lgdi32 -lcrypt32
+else
+  PKG_CPPFLAGS += $(shell pkg-config --cflags openssl)
+  PKG_LIBS = $(shell pkg-config --libs openssl)
+endif
+


### PR DESCRIPTION
This patch switches to using openssl from the system, when available via pkg-config or otherwise using hard-coded library dependencies. It makes the package work with openssl from Rtools42-45. Behavior with previous versions of R is not affected, as this uses the .ucrt version of Makevars.

Using libraries from the system/Rtools when available is required by the CRAN repository policy. Also, it silences a warning (now on CRAN results) about using non-allowed external symbols.
