### PR TITLE
Fix build for R-4.2

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,9 +1,7 @@
 PKG_CPPFLAGS = -I./lib -D_WEBSOCKETPP_CPP11_THREAD_
-
-ifeq (,$(shell pkg-config --version 2>/dev/null))
+PKG_LIBS = $(shell pkg-config --libs openssl)
+ifeq ($(PKG_LIBS),)
   PKG_LIBS = -lssl -lcrypto -lz -lws2_32 -lgdi32 -lcrypt32
 else
   PKG_CPPFLAGS += $(shell pkg-config --cflags openssl)
-  PKG_LIBS = $(shell pkg-config --libs openssl)
 endif
-


### PR DESCRIPTION
or other systems without openssl.pc