### PR TITLE
chore(license): Migrate GPL-2 license to MIT

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^configure.log$
 ^revdep$
 ^pkgdown$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Authors@R: c(
     person("Micael", "Hildenborg", role = c("ctb", "cph"), comment = "SHA1 library"),
     person(family = "Aladdin Enterprises", role = "cph", comment = "MD5 library"),
     person("Bjoern", "Hoehrmann", role = c("ctb", "cph"), comment = "UTF8 Validation library"))
-License: GPL-2
+License: MIT + file LICENSE
 Encoding: UTF-8
 ByteCompile: true
 Imports:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2025
+COPYRIGHT HOLDER: websocket authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2025 websocket authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # websocket (development version)
 
+* Migrate license from GPL-2 to MIT. (#122)
+
 # websocket 1.4.4
 
 * Silences inaccurate deprecation warnings from certain C++ compilers. (#116)


### PR DESCRIPTION
This pull request updates the licensing of the project by migrating from GPL-2 to the MIT license. It includes changes to multiple files to reflect this update, such as adding a new `LICENSE.md` file, updating the `DESCRIPTION` file, and modifying `.Rbuildignore` to include the new license file.
